### PR TITLE
Make a bit more idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ This is a sample application that demonstrates how to perform a very basic
 
 This sample contains configuration for two authorization servers: [Auth0](https://auth0.com) and Google. You can change between then by altering the configuration on line 18 of `auth.clj`:
 
-```clj
-; Change this between :auth0 and :google to try out the different providers
-(def config (:google configs))
-```
+You can use the radio buttons to change between Google and Auth0
+authorization servers.
 
 Details for the authorization servers are already provided, but try altering them to use your own, or even try to add another OIDC-supported authorization server!
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,39 @@ Details for the authorization servers are already provided, but try altering the
 
 ## Usage
 
+Both of the methods of starting the demo shown below start it in
+development mode. This means any code you change and save will be hot
+reloaded.
+
+### Running from Lein
 Run the app using Leiningen:
 
 ```sh
-lein run 9000
+lein run 3000
+```
+### In a REPL
+
+Start your REPL, for example:
+
+``` sh
+lein repl
+```
+
+You can then start the server using:
+
+``` sh
+user=> (go)
+```
+
+You can stop the server with:
+
+``` sh
+user=> (stop)
 ```
 
 ## License
 
-Copyright © 2019 FIXME
+Copyright © 2019 Steve Hobbs
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which is available at

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,27 @@
+(ns user
+  (:require [todo-list.core :as core]))
+
+(def server (atom nil))
+
+(defn go
+  []
+  (reset! server (core/-dev-main 3000)))
+
+(defn stop
+  []
+  (.stop @server))
+
+(defn reset
+  []
+  (stop)
+  (go))
+
+(comment
+
+  (go)
+  @server
+  (stop)
+
+  (reset)
+
+  )

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject todo-list "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+  :description "Demo of how to interact with an OpenID Connect Authorization Server"
+  :url "http://github.com/elkdanger"
   :license {:name "MIT"}
 
   :dependencies [[org.clojure/clojure "1.10.0"]
@@ -8,9 +8,11 @@
                  [ring "1.7.1"]
                  [compojure "1.3.4"]
                  [hiccup "1.0.5"]
-                 [jwt-verify-jwks "1.0.2"]]
+                 [jwt-verify-jwks "1.0.2"]
+                 [com.cemerick/url "0.1.1"]]
 
-  :repl-options {:init-ns todo-list.core}
+  :repl-options {:init-ns user}
   :main todo-list.core/-dev-main
 
-  :profiles {:dev {:main todo-list.core/-dev-main}})
+  :profiles {:dev {:source-paths ["dev" "src"]
+                   :main todo-list.core/-dev-main}})

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/data.json "0.2.6"]
                  [ring "1.7.1"]
+                 [ring/ring-anti-forgery "1.3.0"]
                  [compojure "1.3.4"]
                  [hiccup "1.0.5"]
                  [jwt-verify-jwks "1.0.2"]

--- a/src/todo_list/auth.clj
+++ b/src/todo_list/auth.clj
@@ -27,8 +27,8 @@
        (string/join "&")))
 
 (defn build-url
-  []
-  (str (:authz-endpoint config) "?" (build-params {"redirect_uri" "http://localhost:3000/callback"
+  [port]
+  (str (:authz-endpoint config) "?" (build-params {"redirect_uri" (format "http://localhost:%d/callback" port)
                                                    "response_type" "token id_token"
                                                    "response_mode" "form_post"
                                                    "client_id" (:client-id config)

--- a/src/todo_list/auth.clj
+++ b/src/todo_list/auth.clj
@@ -1,8 +1,9 @@
 (ns todo-list.auth
-  (:require [ring.util.codec :refer [url-encode]]
-            [ring.util.response :refer [content-type]]
+  (:require [clojure.data.json :as json]
+            [clojure.string :as string]
+            [cemerick.url :refer [url]]
             [jwt-verify-jwks.core :refer [jwt-validate-jwks]]
-            [clojure.data.json :as json]
+            [ring.util.codec :refer [url-encode]]
             [todo-list.views.core :as views]))
 
 (def configs {:auth0 {:client-id "nw1AjlUNOiVfKGQpfvQ69q7k9YQhtZ0M"
@@ -12,17 +13,18 @@
               :google {:client-id "1019975522899-sr4hra1temeitlfl04apbvejl1euftav.apps.googleusercontent.com"
                        :authz-endpoint "https://accounts.google.com/o/oauth2/v2/auth"
                        :jwks-uri "https://www.googleapis.com/oauth2/v3/certs"
-                       :issuer "https://accounts.google.com"}})
+                       :issuer "accounts.google.com"}})
 
 ; Change this between :auth0 and :google to try out the different providers
 (def config (:google configs))
 
 (defn build-params
   [m]
-  (->> (for [[k v] m]
-         (str (url-encode k) "=" (url-encode v)))
-       (interpose "&")
-       (apply str)))
+  (->> m
+       (reduce-kv (fn [acc k v]
+                    (conj acc (str (url-encode k) "=" (url-encode v))))
+                  [])
+       (string/join "&")))
 
 (defn build-url
   []
@@ -34,25 +36,29 @@
                                                    "nonce" "345783923"})))
 
 
-(defn check-issuer
+(defn invalid-issuer?
   [profile]
-  (= (:iss profile) (:issuer config)))
+  (not= (-> profile :iss url :host) (:issuer config)))
 
-(defn check-audience
+(defn invalid-audience?
   [profile]
-  (= (:aud profile) (:client-id config)))
+  (not= (:aud profile) (:client-id config)))
 
 (defn validate-token
   [id_token]
   (let [profile (jwt-validate-jwks id_token (:jwks-uri config) "rs256")]
-    (if (check-issuer profile) true (throw (Exception. "Invalid issuer")))
-    (if (check-audience profile) true (throw (Exception. "Invalid audience")))
-    profile))
+    (cond
+      (invalid-issuer? profile) (throw (ex-info "Invalid issuer"))
+      (invalid-audience? profile) (throw (ex-info "Invalid audience"))
+      :else profile)))
 
 (defn handle-callback
   [request]
   (let [id_token (get-in request [:params "id_token"])]
-    (try (let [profile (validate-token id_token)]
-           {:status 200
-            :body (json/write-str profile)
-            :headers {"content-type" "application/json"}}) (catch Exception e {:status 401 :body (views/html-page "Unauthorized" (views/unauthorized))}))))
+    (try
+      (let [profile (validate-token id_token)]
+        {:status 200
+         :body (json/write-str profile)
+         :headers {"content-type" "application/json"}})
+      (catch Exception _
+        {:status 401 :body (views/html-page "Unauthorized" (views/unauthorized))}))))

--- a/src/todo_list/auth.clj
+++ b/src/todo_list/auth.clj
@@ -15,7 +15,6 @@
                        :jwks-uri "https://www.googleapis.com/oauth2/v3/certs"
                        :issuer "accounts.google.com"}})
 
-; Change this between :auth0 and :google to try out the different providers
 (def config (atom nil))
 
 (defn build-params

--- a/src/todo_list/base_routes.clj
+++ b/src/todo_list/base_routes.clj
@@ -8,8 +8,9 @@
    :body (views/html-page "Welcome" (views/welcome))
    :headers {}})
 
-(defn login [request]
-  (redirect (auth/build-url)))
+(defn login [port]
+  (fn [request]
+   (redirect (auth/build-url port))))
 
 (defn request-info
   "View the details about the request"

--- a/src/todo_list/base_routes.clj
+++ b/src/todo_list/base_routes.clj
@@ -9,8 +9,9 @@
    :headers {}})
 
 (defn login [port]
-  (fn [request]
-   (redirect (auth/build-url port))))
+  (fn [{:keys [form-params]}]
+    (let [auth-type (-> form-params (get "auth-type" "google") keyword)]
+     (redirect (auth/build-url port auth-type)))))
 
 (defn request-info
   "View the details about the request"

--- a/src/todo_list/core.clj
+++ b/src/todo_list/core.clj
@@ -12,7 +12,7 @@
   [port]
   (routes
    (GET "/" [] base-routes/welcome)
-   (GET "/login" [] (base-routes/login port))
+   (POST "/login" [] (base-routes/login port))
    (POST "/callback" [] handle-callback)
    (GET "/request-info" [] base-routes/request-info)
    (not-found (views/html-page "Page not found" (views/not-found)))))

--- a/src/todo_list/core.clj
+++ b/src/todo_list/core.clj
@@ -24,4 +24,5 @@
   "A very simple web server (development mode)"
   [port-number]
   (jetty/run-jetty (wrap-reload (wrap-params #'app))
-                   {:port (Integer. port-number)}))
+                   {:port (Integer. port-number)
+                    :join? false}))

--- a/src/todo_list/core.clj
+++ b/src/todo_list/core.clj
@@ -2,18 +2,20 @@
   (:require [ring.adapter.jetty :as jetty]
             [ring.middleware.reload :refer [wrap-reload]]
             [ring.middleware.params :refer [wrap-params]]
-            [compojure.core :refer [defroutes GET POST]]
+            [compojure.core :refer [routes GET POST]]
             [compojure.route :refer [not-found]]
-            [todo-list.base-routes :as routes]
+            [todo-list.base-routes :as base-routes]
             [todo-list.auth :refer [handle-callback]]
             [todo-list.views.core :as views]))
 
-(defroutes app
-  (GET "/" [] routes/welcome)
-  (GET "/login" [] routes/login)
-  (POST "/callback" [] handle-callback)
-  (GET "/request-info" [] routes/request-info)
-  (not-found (views/html-page "Page not found" (views/not-found))))
+(defn app
+  [port]
+  (routes
+   (GET "/" [] base-routes/welcome)
+   (GET "/login" [] (base-routes/login port))
+   (POST "/callback" [] handle-callback)
+   (GET "/request-info" [] base-routes/request-info)
+   (not-found (views/html-page "Page not found" (views/not-found)))))
 
 (defn -main
   "A very simple web server"
@@ -23,6 +25,7 @@
 (defn -dev-main
   "A very simple web server (development mode)"
   [port-number]
-  (jetty/run-jetty (wrap-reload (wrap-params #'app))
-                   {:port (Integer. port-number)
-                    :join? false}))
+  (let [port (Integer. port-number)]
+   (jetty/run-jetty (wrap-reload (wrap-params (app port)))
+                    {:port port
+                     :join? false})))

--- a/src/todo_list/views/core.clj
+++ b/src/todo_list/views/core.clj
@@ -1,6 +1,8 @@
 (ns todo-list.views.core
   (:require [hiccup.page :refer [html5 include-css]]
-            [hiccup.element :refer [link-to]]))
+            [hiccup.form :refer [form-to label text-field text-area radio-button submit-button]]
+            [hiccup.element :refer [link-to]]
+            [ring.util.anti-forgery :refer [anti-forgery-field]]))
 
 (defn html-page [title & content]
   (html5
@@ -14,7 +16,18 @@
   [:div#main-content
    [:h1 "Hello, Clojure!"]
    [:p.lead "This is an Open ID Connect demo!"]
-   (link-to {:class "btn btn-primary"} "/login" "Log in to the site")])
+   (form-to [:post "/login"]
+            (anti-forgery-field)
+            [:div.row
+             [:div.form-group.col-12
+               [:div.form-check.col
+                (radio-button {:class "form-check-input"} "auth-type" true "google")
+                (label {:class "form-check-label"} "label-google" "Google")]]
+             [:div.form-group.col-12
+              [:div.form-check.col
+                (radio-button {:class "form-check-input"} "auth-type" false "auth0")
+                (label {:class "form-check-label"} "label-google" "Auth0")]]]
+            (submit-button {:class "btn btn-primary text-center"} "Log in to the site"))])
 
 (defn not-found []
   [:div

--- a/src/todo_list/views/core.clj
+++ b/src/todo_list/views/core.clj
@@ -17,11 +17,11 @@
    (link-to {:class "btn btn-primary"} "/login" "Log in to the site")])
 
 (defn not-found []
-  '([:div
-     [:h1 "Page not found"]]))
+  [:div
+   [:h1 "Page not found"]])
 
 (defn unauthorized []
-  `([:h1 "Unauthorized"]))
+  [:h1 "Unauthorized"])
 
 (comment
   (html-page "Example" [:h1 "Page not found"]))


### PR DESCRIPTION
The config being saved in an atom is really hacky. The better way to do this would be to pass the `auth-type` (i.e. google or auth0) as a param in the callback URL and then parse it out of the URL in `handle-callback`. Then you could remove the `config` def.
I tried this but it would require changes in the authentication server allowed callback URL.
I also parameterised the port for the server but again it doesn't work unless it's port 3000 because that's what the server expects.